### PR TITLE
build.gradle: Sync with pom.xml and fix generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 ext.pluginClassNames='com.dtolabs.rundeck.plugin.overthere.OTWinRMNodeExecutor,com.dtolabs.rundeck.plugin.overthere.OTWinRMFileCopier'
 
 defaultTasks 'clean','build'
-version = '1.3.3-SNAPSHOT'
+version = '1.3.4-SNAPSHOT'
 ext.rundeckPluginVersion= '1.1'
 apply plugin: 'java'
 apply plugin: 'idea'
@@ -114,51 +114,58 @@ task createPom << {
                 }
             }
 
-            build{
-                plugins{
-                    plugin{
-                        artifactId 'maven-compiler-plugin'
-                        version '2.3.2'
-                        configuration{
-                            source '1.6'
-                            target '1.6'
-                        }
-                    }
-                    plugin() {
-                        artifactId('maven-assembly-plugin')
-                        version('2.2.2')
-                        executions() {
-                            execution() {
-                                id('make-assembly')
-                                phase('package')
-                                goals() {
-                                    goal('single')
-                                }
-                            }
-                        }
-                        configuration() {
-                            appendAssemblyId('false')
-                            descriptors() {
-                                descriptor('src/main/assembly/jar.xml')
-                            }
-                            archive() {
-                                manifestEntries() {
-                                    'Rundeck-Plugin-Version'(rundeckPluginVersion)
-                                    'Rundeck-Plugin-File-Version'(version)
-                                    'Rundeck-Plugin-Archive'('true')
-                                    'Rundeck-Plugin-Classnames'(pluginClassNames)
-                                    'Rundeck-Plugin-Libs'(libList)
-                                }
-                            }
-                        }
-                    }
-                }
+            properties {
+                'plugin.release.version'('2.5.1')
             }
+
             scm{
                 connection 'scm:git:git@github.com:rundeck-plugins/rundeck-winrm-plugin.git'
                 developerConnection 'scm:git:git@github.com:rundeck-plugins/rundeck-winrm-plugin.git'
                 url 'git@github.com:rundeck-plugins/rundeck-winrm-plugin.git'
                 tag 'HEAD'
+            }
+        }
+    }.withXml {
+        asNode().appendNode('build').with {
+            appendNode('plugins').with {
+                appendNode('plugin').with {
+                    appendNode('artifactId', 'maven-compiler-plugin')
+                    appendNode('version', '2.3.2')
+                    appendNode('configuration').with {
+                        appendNode('source', '1.6')
+                        appendNode('target', '1.6')
+                    }
+                }
+                appendNode('plugin').with {
+                    appendNode('artifactId', 'maven-assembly-plugin')
+                    appendNode('version', '2.2.2')
+                    appendNode('executions').appendNode('execution').with {
+                        appendNode('id', 'make-assembly')
+                        appendNode('phase', 'package')
+                        appendNode('goals').with {
+                            appendNode('goal', 'single')
+                        }
+                    }
+                    appendNode('configuration').with {
+                        appendNode('appendAssemblyId', 'false')
+                        appendNode('descriptors').with {
+                            appendNode('descriptor', 'src/main/assembly/jar.xml')
+                        }
+                        appendNode('archive').with {
+                            appendNode('manifestEntries').with {
+                                appendNode('Rundeck-Plugin-Version', this.rundeckPluginVersion)
+                                appendNode('Rundeck-Plugin-File-Version', this.version)
+                                appendNode('Rundeck-Plugin-Archive', 'true')
+                                appendNode('Rundeck-Plugin-Classnames', this.pluginClassNames)
+                                appendNode('Rundeck-Plugin-Libs', libList)
+                            }
+                        }
+                    }
+                }
+                appendNode('plugin').with {
+                    appendNode('artifactId', 'maven-release-plugin')
+                    appendNode('version', '${plugin.release.version}')
+                }
             }
         }
     }.writeTo("pom.xml")

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>rundeck-plugins-parent</artifactId>
     <groupId>org.rundeck-plugins</groupId>
+    <artifactId>rundeck-plugins-parent</artifactId>
     <version>2</version>
   </parent>
   <groupId>org.rundeck-plugins</groupId>
@@ -19,15 +19,34 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-  <properties>
-    <plugin.release.version>2.5.1</plugin.release.version>
-  </properties>
   <scm>
     <connection>scm:git:git@github.com:rundeck-plugins/rundeck-winrm-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:rundeck-plugins/rundeck-winrm-plugin.git</developerConnection>
     <url>git@github.com:rundeck-plugins/rundeck-winrm-plugin.git</url>
-    <tag>HEAD</tag>
   </scm>
+  <properties>
+    <plugin.release.version>2.5.1</plugin.release.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.rundeck</groupId>
+      <artifactId>rundeck-core</artifactId>
+      <version>2.3.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-nop</artifactId>
+      <version>1.6.3</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.xebialabs.overthere</groupId>
+      <artifactId>overthere</artifactId>
+      <version>4.3.0</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>
@@ -58,10 +77,10 @@
           <archive>
             <manifestEntries>
               <Rundeck-Plugin-Version>1.1</Rundeck-Plugin-Version>
-              <Rundeck-Plugin-File-Version>1.3.2-SNAPSHOT</Rundeck-Plugin-File-Version>
+              <Rundeck-Plugin-File-Version>1.3.4-SNAPSHOT</Rundeck-Plugin-File-Version>
               <Rundeck-Plugin-Archive>true</Rundeck-Plugin-Archive>
-              <Rundeck-Plugin-Classnames>com.dtolabs.rundeck.plugin.overthere.OTWinRMNodeExecutor</Rundeck-Plugin-Classnames>
-              <Rundeck-Plugin-Libs>lib/overthere-4.3.0.jar lib/slf4j-nop-1.6.3.jar lib/jcifs-1.3.17.jar lib/httpcore-4.4.1.jar lib/commons-codec-1.10.jar lib/slf4j-api-1.7.12.jar lib/truezip-file-7.7.8.jar lib/javassist-3.17.1-GA.jar lib/commons-compress-1.9.jar lib/truezip-driver-zip-7.7.8.jar lib/annotations-3.0.0.jar lib/truezip-kernel-7.7.8.jar lib/scannit-1.4.0.jar lib/truezip-driver-file-7.7.8.jar lib/httpclient-4.4.1.jar</Rundeck-Plugin-Libs>
+              <Rundeck-Plugin-Classnames>com.dtolabs.rundeck.plugin.overthere.OTWinRMNodeExecutor,com.dtolabs.rundeck.plugin.overthere.OTWinRMFileCopier</Rundeck-Plugin-Classnames>
+              <Rundeck-Plugin-Libs>lib/overthere-4.3.0.jar lib/slf4j-nop-1.6.3.jar lib/jcifs-1.3.17.jar lib/httpcore-4.4.1.jar lib/httpclient-4.4.1.jar lib/slf4j-api-1.7.12.jar lib/scannit-1.4.0.jar lib/commons-codec-1.10.jar lib/truezip-file-7.7.8.jar lib/javassist-3.17.1-GA.jar lib/truezip-driver-zip-7.7.8.jar lib/truezip-kernel-7.7.8.jar lib/truezip-swing-7.7.8.jar lib/commons-compress-1.9.jar lib/annotations-3.0.0.jar lib/truezip-driver-file-7.7.8.jar</Rundeck-Plugin-Libs>
             </manifestEntries>
           </archive>
         </configuration>
@@ -72,24 +91,4 @@
       </plugin>
     </plugins>
   </build>
-  <dependencies>
-    <dependency>
-      <groupId>org.rundeck</groupId>
-      <artifactId>rundeck-core</artifactId>
-      <version>2.3.2</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-nop</artifactId>
-      <version>1.6.3</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.xebialabs.overthere</groupId>
-      <artifactId>overthere</artifactId>
-      <version>4.3.0</version>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
 </project>


### PR DESCRIPTION
The difference visible here, between the hand-written pom.xml and the
generated ones, boils down to the reordering of sections.